### PR TITLE
Don't try to set element.textContent unless it's defined

### DIFF
--- a/emojie.js
+++ b/emojie.js
@@ -22,7 +22,9 @@
 
   function emojiElement(emoji, options) {
     var element = document.createElement(options["elementName"] || "img");
-    element.textContent = options["content"];
+    if (options["content"] != null) {
+      element.textContent = options["content"];
+    }
 
     for (attr in options) {
       if (attr != "content" && attr != "elementName") {


### PR DESCRIPTION
Before this the html created with 

```
emojie.register('foo', {title: 'foo', src: 'http...', class: 'emojie'});
```

was

```
<img src="html..." class="emojie" title="foo">undefined</img>
```
