### PR TITLE
Draw the emoji in canRender into the checked rectangle

### DIFF
--- a/emojie.js
+++ b/emojie.js
@@ -93,6 +93,7 @@
 
     try {
       var ctx = document.createElement("canvas").getContext("2d");
+      ctx.textBaseline = "top";
       ctx.fillText(emoji, 0, 0);
 
       return hasColor(ctx, 10);


### PR DESCRIPTION
Canvas coordinate system is based in top-left corner (0,0), but when drawing text it is the lower left corner that is the anchor. Current implementation actually draws the emoji out of the box that's checked for existence of the text (or actually just the bottom line is within the boundary). Adding the `textBaseline` changes the anchor point to top left corner and the emoji is actually rendered into view.
